### PR TITLE
MeterianBot has fixed some issues in your codebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.meterian.qa.samples</groupId>
@@ -31,7 +29,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.11</version>
+            <version>1.2.10</version>
         </dependency>
 
         <!-- has major version 4.1.12 (inentionally NOT in test scope) -->
@@ -45,7 +43,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
 
         <!-- adding new dependencies for test-->
@@ -53,7 +51,7 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-version</artifactId>
-            <version>11.0.0.Beta8</version>
+            <version>11.1.1.Final</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hey! We’ve found issues with some of the libraries you are using in your project, **MeterianBot** managed to fix some of them for you but unfortunately not all of them. They just need your approval.

The security score of your project is **80**, the stability score **100** and the licensing score **100**.
You can have a more detailed look at the report [here](https://qa.meterian.com/projects/?pid=88fc5368-409d-4fd2-9421-4a256506220f&branch=master&mode=eli).

## Fixes
We’ve updated **ch.qos.logback:logback-core** from the outdated version **1.1.11** to **1.2.10** minor release

---

We’ve updated **org.wildfly.core:wildfly-version** from the outdated version **11.0.0.Beta8** to **11.1.1.Final** minor release

---

We’ve updated **mysql:mysql-connector-java** from the outdated version **8.0.15** to **8.0.28** patch release

---

## Issues
**com.google.protobuf:protobuf-java** **3.6.1**  is affected by a security vulnerability: **[CVE-2021-22569](https://nvd.nist.gov/vuln/details/CVE-2021-22569)**.

&nbsp;&nbsp;&nbsp;&nbsp;Threat severity: **HIGH** &nbsp;&nbsp;&nbsp;&nbsp; CVSS score: **8**

>A potential Denial of Service issue in protobuf-java was discovered in the parsing procedure for binary data.

&nbsp;&nbsp;&nbsp;&nbsp;com.google.protobuf:protobuf-java 3.19.4 minor release and 4.0.0-rc-2 major release are the next safe versions.

---

**junit:junit** **3.8.2** is outdated

&nbsp;&nbsp;&nbsp;&nbsp;junit:junit 4.13.2 major release is the latest available version.

---

## Licenses

Have a look at the [report](https://qa.meterian.com/projects/?pid=88fc5368-409d-4fd2-9421-4a256506220f&branch=master&mode=eli) for more details and find out [how a licenses can impact your business](https://blog.meterian.com/2019/05/22/how-the-wrong-license-can-harm-your-business/).